### PR TITLE
UI/UX 디테일 개선 — 색상 대비, iOS 입력 줌 방지, 버튼 정렬

### DIFF
--- a/src/app/components/CalendarView.tsx
+++ b/src/app/components/CalendarView.tsx
@@ -261,7 +261,7 @@ export function CalendarView({ tasks, teamId }: CalendarViewProps) {
       <div className="mb-4 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
         <div>
           <p className="text-[0.7rem] uppercase tracking-[0.4em] text-slate-400">Calendar</p>
-          <p className="mt-1 text-sm text-slate-500">마감일 기준 표시</p>
+          <p className="mt-1 text-sm text-slate-400">마감일 기준 표시</p>
         </div>
         <div className="flex items-center gap-2">
           <button
@@ -452,7 +452,7 @@ export function CalendarView({ tasks, teamId }: CalendarViewProps) {
       {/* 날짜 미지정 태스크 */}
       {tasksWithoutDate.length > 0 && (
         <div className="mt-6">
-          <p className="mb-3 text-xs font-semibold text-slate-500">날짜 미지정 ({tasksWithoutDate.length})</p>
+          <p className="mb-3 text-xs font-semibold text-slate-400">날짜 미지정 ({tasksWithoutDate.length})</p>
           <div className="flex flex-wrap gap-2">
             {tasksWithoutDate.map(task => (
               <div
@@ -497,7 +497,7 @@ export function CalendarView({ tasks, teamId }: CalendarViewProps) {
           {/* 태스크 목록 */}
           <div className="p-2 space-y-1.5">
             {popover.tasks.length === 0 ? (
-              <p className="text-center text-xs text-slate-500 py-4">태스크가 없습니다</p>
+              <p className="text-center text-xs text-slate-400 py-4">태스크가 없습니다</p>
             ) : (
               popover.tasks.map(task => {
                 const { status: deadlineStatus } = getTaskDeadlineInfo(task);

--- a/src/app/components/GanttChart.tsx
+++ b/src/app/components/GanttChart.tsx
@@ -116,7 +116,7 @@ export function GanttChart({ tasks, teamId }: GanttChartProps) {
                     }`}
                     style={{ width: cellWidth }}
                   >
-                    <span className={`text-[10px] ${isTodayDate ? 'font-bold text-sky-400' : 'text-slate-500'}`}>
+                    <span className={`text-[10px] ${isTodayDate ? 'font-bold text-sky-400' : 'text-slate-400'}`}>
                       {formatDateDisplay(date)}
                     </span>
                   </div>
@@ -201,7 +201,7 @@ export function GanttChart({ tasks, teamId }: GanttChartProps) {
           {sortedTasks.withoutStartDate.length > 0 && (
             <div className="mt-4">
               <div className="mb-2 px-3">
-                <span className="text-xs font-semibold text-slate-500">날짜 미지정</span>
+                <span className="text-xs font-semibold text-slate-400">날짜 미지정</span>
               </div>
               {sortedTasks.withoutStartDate.map(task => {
                 const colors = getStatusColors(task.taskStatus);

--- a/src/app/components/Kanban.tsx
+++ b/src/app/components/Kanban.tsx
@@ -132,7 +132,7 @@ export function Kanban({ tasksByColumn, onStatusChange, teamId, isArchiveView, o
                     />
                     <div>
                       <p className="text-sm font-semibold text-white">{status.label}</p>
-                      <p className="text-xs text-slate-500">{status.description}</p>
+                      <p className="text-xs text-slate-400">{status.description}</p>
                     </div>
                   </div>
                   <span className="text-xs font-semibold text-slate-400">

--- a/src/app/components/ListView.tsx
+++ b/src/app/components/ListView.tsx
@@ -178,7 +178,7 @@ export function ListView({ tasks, teamId, isArchiveView, onRestore }: ListViewPr
                       <div className="max-w-[200px]">
                         <p className="truncate text-sm font-medium text-slate-200">{task.taskName}</p>
                         {task.taskDescription && (
-                          <p className="mt-0.5 truncate text-xs text-slate-500">{task.taskDescription}</p>
+                          <p className="mt-0.5 truncate text-xs text-slate-400">{task.taskDescription}</p>
                         )}
                       </div>
                     </td>
@@ -230,7 +230,7 @@ export function ListView({ tasks, teamId, isArchiveView, onRestore }: ListViewPr
       </div>
 
       {/* 결과 카운트 */}
-      <div className="mt-4 text-right text-xs text-slate-500">
+      <div className="mt-4 text-right text-xs text-slate-400">
         {sortedTasks.length}개 태스크
       </div>
     </div>

--- a/src/app/components/PublicFooter.tsx
+++ b/src/app/components/PublicFooter.tsx
@@ -3,7 +3,7 @@ import { SITE_CONFIG } from '../config/siteConfig';
 
 export default function PublicFooter() {
   return (
-    <footer className="border-t border-slate-800 bg-slate-950 px-4 py-8 text-sm text-slate-500">
+    <footer className="border-t border-slate-800 bg-slate-950 px-4 py-8 text-sm text-slate-400">
       <div className="mx-auto flex max-w-2xl flex-col items-center gap-4">
         <nav className="flex flex-wrap justify-center gap-x-6 gap-y-2">
           <Link href="/" className="hover:text-slate-300 transition-colors">홈</Link>

--- a/src/app/components/TaskCard.tsx
+++ b/src/app/components/TaskCard.tsx
@@ -122,7 +122,7 @@ export function TaskCard({ task, onStatusChange, teamId, isArchiveView, onRestor
 
         {/* 담당자 */}
         <div className="mt-3 flex items-center justify-between">
-          <span className="text-xs text-slate-500 truncate max-w-[60%]">
+          <span className="text-xs text-slate-400 truncate max-w-[60%]">
             {userName || `사용자 ${crtdBy}`}
           </span>
         </div>

--- a/src/app/components/TaskFilters.tsx
+++ b/src/app/components/TaskFilters.tsx
@@ -86,7 +86,7 @@ export function TaskFilters({
             value={searchQuery}
             onChange={e => onSearchChange(e.target.value)}
             placeholder="태스크 검색..."
-            className="w-full rounded-xl border border-white/10 bg-slate-900/50 pl-10 pr-10 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:border-sky-500/50 focus:outline-none"
+            className="w-full rounded-xl border border-white/10 bg-slate-900/50 pl-10 pr-10 py-2.5 text-base text-slate-200 placeholder-slate-500 focus:border-sky-500/50 focus:outline-none"
           />
           <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
           {searchQuery && (
@@ -134,7 +134,7 @@ export function TaskFilters({
             {currentUserId && (
               <button
                 onClick={handleMyTasksToggle}
-                className={`flex-1 py-2.5 rounded-lg text-xs font-semibold transition ${
+                className={`flex-1 py-2.5 rounded-lg text-base font-semibold transition ${
                   assigneeId === currentUserId
                     ? 'bg-sky-500/20 text-sky-400 border border-sky-500/30'
                     : 'border border-white/10 bg-slate-900/50 text-slate-400 hover:bg-slate-800/50'
@@ -146,7 +146,7 @@ export function TaskFilters({
             <select
               value={assigneeId ?? ''}
               onChange={e => onAssigneeChange(e.target.value === '' ? null : Number(e.target.value))}
-              className="flex-1 max-w-full box-border px-3 py-2.5 rounded-lg border border-white/10 bg-slate-900/50 text-xs text-slate-200 focus:outline-none"
+              className="flex-1 max-w-full box-border px-3 py-2.5 rounded-lg border border-white/10 bg-slate-900/50 text-base text-slate-200 focus:outline-none"
             >
               <option value="">모든 담당자</option>
               {assignees.map(a => (
@@ -157,7 +157,7 @@ export function TaskFilters({
 
           {/* 상태 버튼 그리드 */}
           <div>
-            <label className="block text-[10px] text-slate-500 mb-2">상태</label>
+            <label className="block text-[10px] text-slate-400 mb-2">상태</label>
             <div className="grid grid-cols-3 gap-1.5">
               <button
                 onClick={() => onStatusChange('all')}
@@ -190,7 +190,7 @@ export function TaskFilters({
 
           {/* 기간 버튼 */}
           <div>
-            <label className="block text-[10px] text-slate-500 mb-2">기간</label>
+            <label className="block text-[10px] text-slate-400 mb-2">기간</label>
             <div className="flex gap-1.5 flex-wrap">
               {periodOptions.map(opt => (
                 <button

--- a/src/app/fishing/(game)/page.tsx
+++ b/src/app/fishing/(game)/page.tsx
@@ -9,7 +9,7 @@ const GameCanvas = dynamic(() => import('../components/GameCanvas'), {
   ssr: false,
   loading: () => (
     <div className="flex items-center justify-center h-full bg-slate-900">
-      <p className="text-slate-500 text-sm">게임 로딩 중...</p>
+      <p className="text-slate-400 text-sm">게임 로딩 중...</p>
     </div>
   ),
 });

--- a/src/app/fishing/components/FishResultModal.tsx
+++ b/src/app/fishing/components/FishResultModal.tsx
@@ -162,7 +162,7 @@ export default function FishResultModal({ type, fish, onDismiss }: FishResultMod
         <div className="relative bg-slate-900/95 border border-slate-700/50 rounded-2xl p-6 mx-6 max-w-xs w-full text-center animate-fadeIn">
           <p className="text-4xl mb-3">💨</p>
           <p className="text-slate-300 text-lg font-bold mb-1">물고기가 도망갔습니다!</p>
-          <p className="text-slate-500 text-sm mb-4">다음엔 꼭 잡아봅시다...</p>
+          <p className="text-slate-400 text-sm mb-4">다음엔 꼭 잡아봅시다...</p>
           <button
             onClick={onDismiss}
             className="bg-slate-700 hover:bg-slate-600 text-slate-200 px-6 py-2.5 rounded-xl text-sm font-medium transition-colors"
@@ -259,11 +259,11 @@ export default function FishResultModal({ type, fish, onDismiss }: FishResultMod
           {/* 스탯 */}
           <div className="flex justify-center gap-6 mb-4">
             <div>
-              <p className="text-xs text-slate-500">크기</p>
+              <p className="text-xs text-slate-400">크기</p>
               <p className="text-lg font-bold text-slate-200">{fish.size}cm</p>
             </div>
             <div>
-              <p className="text-xs text-slate-500">무게</p>
+              <p className="text-xs text-slate-400">무게</p>
               <p className="text-lg font-bold text-slate-200">{formatWeight(fish.weight)}</p>
             </div>
           </div>

--- a/src/app/fishing/components/FishingHUD.tsx
+++ b/src/app/fishing/components/FishingHUD.tsx
@@ -148,7 +148,7 @@ function KeyboardHint({ fishingState, hasNearbyPoint }: { fishingState: FishingS
       style={{ bottom: 'calc(1.5rem + env(safe-area-inset-bottom, 0px))' }}
     >
       <div className="bg-slate-900/60 rounded-lg px-3 py-1 border border-slate-700/30">
-        <span className="text-[10px] text-slate-500">{hint}</span>
+        <span className="text-[10px] text-slate-400">{hint}</span>
       </div>
     </div>
   );

--- a/src/app/fishing/components/InventoryPanel.tsx
+++ b/src/app/fishing/components/InventoryPanel.tsx
@@ -49,7 +49,7 @@ export default function InventoryPanel({ inventory, isOpen, onClose }: Inventory
           {inventory.length === 0 ? (
             <div className="text-center py-8">
               <p className="text-2xl mb-2">🎣</p>
-              <p className="text-sm text-slate-500">아직 잡은 물고기가 없습니다</p>
+              <p className="text-sm text-slate-400">아직 잡은 물고기가 없습니다</p>
               <p className="text-xs text-slate-600 mt-1">낚시 포인트 근처에서 캐스팅해보세요</p>
             </div>
           ) : (

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -104,7 +104,7 @@ export default function Mypage() {
                 placeholder="닉네임 입력"
                 autoFocus
               />
-              <p className="text-xs text-slate-500 mt-1">{newUserName.length}/20</p>
+              <p className="text-xs text-slate-400 mt-1">{newUserName.length}/20</p>
             </div>
           ) : (
             <div className="mb-3">

--- a/src/app/teams/[teamId]/TeamBoard.tsx
+++ b/src/app/teams/[teamId]/TeamBoard.tsx
@@ -883,7 +883,7 @@ export default function TeamBoard({ teamId }: TeamBoardProps) {
 
         {/* 필터 결과 표시 */}
         {hasActiveFilters && (
-          <div className="text-xs text-slate-500 mt-2">
+          <div className="text-xs text-slate-400 mt-2">
             {filteredTasks.length}개 태스크 표시 중 (전체 {allTasks.length}개)
           </div>
         )}

--- a/src/app/teams/[teamId]/components/DiscordSection.tsx
+++ b/src/app/teams/[teamId]/components/DiscordSection.tsx
@@ -71,7 +71,7 @@ export function DiscordSection({
             </div>
           </div>
           <div className="mb-4 rounded-lg border border-white/5 bg-slate-900/50 p-3">
-            <p className="text-xs text-slate-500 mb-1">Webhook URL</p>
+            <p className="text-xs text-slate-400 mb-1">Webhook URL</p>
             <p className="text-xs font-mono text-slate-300 break-all">
               {discordStatus.webhookUrl.length > 60
                 ? `${discordStatus.webhookUrl.slice(0, 60)}...`
@@ -138,7 +138,7 @@ export function DiscordSection({
           value={webhookUrl}
           onChange={(e) => setWebhookUrl(e.target.value)}
           placeholder="https://discord.com/api/webhooks/..."
-          className="w-full rounded-lg border border-white/20 bg-slate-900/50 px-4 py-2.5 text-xs text-slate-200 placeholder-slate-500 outline-none focus:border-indigo-500/50 transition"
+          className="w-full rounded-lg border border-white/20 bg-slate-900/50 px-4 py-2.5 text-base text-slate-200 placeholder-slate-500 outline-none focus:border-indigo-500/50 transition"
         />
       </div>
       <button

--- a/src/app/teams/[teamId]/components/InviteModal.tsx
+++ b/src/app/teams/[teamId]/components/InviteModal.tsx
@@ -51,7 +51,7 @@ export function InviteModal({
           <div>
             <p className="mb-4 text-sm text-slate-400">초대 링크가 생성되었습니다!</p>
             <div className="mb-4 rounded-lg bg-slate-950/50 border border-white/5 p-3">
-              <p className="mb-2 text-xs text-slate-500">초대 링크:</p>
+              <p className="mb-2 text-xs text-slate-400">초대 링크:</p>
               <p className="break-all text-xs text-slate-300 font-mono">{createdInviteLink}</p>
             </div>
             <button
@@ -105,7 +105,7 @@ function InviteCreateForm({
         <select
           value={expiresInDays}
           onChange={e => setExpiresInDays(Number(e.target.value))}
-          className="w-full max-w-full box-border appearance-none rounded-lg border border-white/10 bg-slate-950/50 px-3 py-2 text-xs text-slate-200 focus:border-white/20 focus:outline-none"
+          className="w-full max-w-full box-border appearance-none rounded-lg border border-white/10 bg-slate-950/50 px-3 py-2 text-base text-slate-200 focus:border-white/20 focus:outline-none"
         >
           {Array.from({ length: 3 }, (_, i) => i + 1).map(days => (
             <option key={days} value={days}>
@@ -113,7 +113,7 @@ function InviteCreateForm({
             </option>
           ))}
         </select>
-        <p className="mt-1 text-xs text-slate-500">일 단위로만 선택할 수 있어요. (1~3일)</p>
+        <p className="mt-1 text-xs text-slate-400">일 단위로만 선택할 수 있어요. (1~3일)</p>
       </div>
 
       <div>
@@ -123,10 +123,10 @@ function InviteCreateForm({
           value={usageMaxCnt}
           onChange={e => setUsageMaxCnt(e.target.value === '' ? '' : Number(e.target.value))}
           min={1}
-          className="w-full max-w-full box-border appearance-none rounded-lg border border-white/10 bg-slate-950/50 px-3 py-2 text-xs text-slate-200 focus:border-white/20 focus:outline-none"
+          className="w-full max-w-full box-border appearance-none rounded-lg border border-white/10 bg-slate-950/50 px-3 py-2 text-base text-slate-200 focus:border-white/20 focus:outline-none"
           placeholder="최대 사용 횟수"
         />
-        <p className="mt-1 text-xs text-slate-500">최대 사용 횟수를 지정하지 않으면 기본값이 적용됩니다.</p>
+        <p className="mt-1 text-xs text-slate-400">최대 사용 횟수를 지정하지 않으면 기본값이 적용됩니다.</p>
       </div>
 
       <div className="flex gap-2 pt-3">

--- a/src/app/teams/[teamId]/components/OnlineUsers.tsx
+++ b/src/app/teams/[teamId]/components/OnlineUsers.tsx
@@ -178,7 +178,7 @@ function OnlineUserListItem({
           )}
         </p>
         {user.connectionCount > 1 && (
-          <p className="text-xs text-slate-500">
+          <p className="text-xs text-slate-400">
             {user.connectionCount}개 기기에서 접속 중
           </p>
         )}

--- a/src/app/teams/[teamId]/components/TeamManagementSection.tsx
+++ b/src/app/teams/[teamId]/components/TeamManagementSection.tsx
@@ -239,7 +239,7 @@ export function TeamManagementSection({
           <SectionLabel>Team Management</SectionLabel>
           <div className="flex items-center gap-2">
             {visibleTabs.map(tab => (
-              <span key={tab.key} className="flex items-center gap-1 text-xs text-slate-500" title={tab.label}>
+              <span key={tab.key} className="flex items-center gap-1 text-xs text-slate-400" title={tab.label}>
                 {tab.icon}
                 {tab.count !== null && tab.count}
               </span>
@@ -358,7 +358,7 @@ export function TeamManagementSection({
                                 </span>
                               )}
                             </div>
-                            <p className="mt-2 text-xs text-slate-500">가입일: {formatMemberDate(member.joinedAt)}</p>
+                            <p className="mt-2 text-xs text-slate-400">가입일: {formatMemberDate(member.joinedAt)}</p>
                           </div>
                           <div className="flex items-center gap-2 flex-shrink-0">
                             {showRoleChangeButton && (
@@ -426,7 +426,7 @@ export function TeamManagementSection({
                     >
                       {stat.value}
                     </p>
-                    <p className="mt-1 text-sm text-slate-500">{stat.helper}</p>
+                    <p className="mt-1 text-sm text-slate-400">{stat.helper}</p>
                   </div>
                 ))}
               </div>
@@ -482,7 +482,7 @@ export function TeamManagementSection({
                             </div>
                             {isActive && (
                               <div className="mt-3 rounded-lg border border-white/5 bg-slate-900/50 p-3">
-                                <p className="mb-1 text-xs text-slate-500">초대 링크:</p>
+                                <p className="mb-1 text-xs text-slate-400">초대 링크:</p>
                                 <p className="break-all font-mono text-xs text-slate-300">{inviteUrl}</p>
                               </div>
                             )}

--- a/src/app/teams/[teamId]/components/TelegramSection.tsx
+++ b/src/app/teams/[teamId]/components/TelegramSection.tsx
@@ -60,7 +60,7 @@ export function TelegramSection({
             </div>
           </div>
           <div className="mb-4 rounded-lg border border-white/5 bg-slate-900/50 p-3">
-            <p className="text-xs text-slate-500 mb-1">Chat ID</p>
+            <p className="text-xs text-slate-400 mb-1">Chat ID</p>
             <p className="text-sm font-mono text-slate-300">{telegramStatus.chatId}</p>
           </div>
           <button
@@ -99,7 +99,7 @@ export function TelegramSection({
           </div>
         </div>
         <div className="mb-4 rounded-lg border border-white/5 bg-slate-900/50 p-3">
-          <p className="text-xs text-slate-500 mb-1">연동 링크</p>
+          <p className="text-xs text-slate-400 mb-1">연동 링크</p>
           <a
             href={telegramStatus.pendingLink.deepLink}
             target="_blank"
@@ -110,7 +110,7 @@ export function TelegramSection({
           </a>
         </div>
         <div className="mb-4 text-xs text-slate-400">
-          <span className="text-slate-500">만료:</span>{' '}
+          <span className="text-slate-400">만료:</span>{' '}
           {formatFullDateTime(new Date(telegramStatus.pendingLink.endAt))}
         </div>
         <div className="flex gap-2">

--- a/src/app/teams/[teamId]/components/TutorialGuide.tsx
+++ b/src/app/teams/[teamId]/components/TutorialGuide.tsx
@@ -113,7 +113,7 @@ export function TutorialGuide({ isOpen, onClose }: TutorialGuideProps) {
           </div>
 
           {/* 스텝 카운터 */}
-          <span className="text-xs text-slate-500 mb-2">
+          <span className="text-xs text-slate-400 mb-2">
             {currentStep + 1} / {STEPS.length}
           </span>
 

--- a/src/app/teams/[teamId]/tasks/[taskId]/TaskDetailPage.tsx
+++ b/src/app/teams/[teamId]/tasks/[taskId]/TaskDetailPage.tsx
@@ -536,7 +536,7 @@ export default function TaskDetailPage({ teamId, taskId }: TaskDetailPageProps) 
             <div className='flex items-start justify-between gap-3 mb-4'>
               <div className='flex-1 min-w-0'>
                 <h1 className='text-xl font-bold text-white break-words'>{taskDetail.taskName}</h1>
-                <span className='mt-1 block text-xs text-slate-500'>
+                <span className='mt-1 block text-xs text-slate-400'>
                   {taskDetail.userName || `사용자 ${taskDetail.crtdBy}`}
                 </span>
               </div>
@@ -626,7 +626,7 @@ export default function TaskDetailPage({ teamId, taskId }: TaskDetailPageProps) 
             value={newComment}
             onChange={e => setNewComment(e.target.value)}
             placeholder='댓글을 입력하세요...'
-            className='flex-1 resize-none rounded-xl border border-white/10 bg-slate-900/60 p-3 text-sm text-white placeholder-slate-500 focus:border-sky-500/50 focus:outline-none focus:ring-2 focus:ring-sky-500/20'
+            className='flex-1 resize-none rounded-xl border border-white/10 bg-slate-900/60 p-3 text-base text-white placeholder-slate-500 focus:border-sky-500/50 focus:outline-none focus:ring-2 focus:ring-sky-500/20'
             rows={2}
           />
           <button
@@ -642,7 +642,7 @@ export default function TaskDetailPage({ teamId, taskId }: TaskDetailPageProps) 
         {/* 댓글 목록 */}
         <div className='space-y-4'>
           {comments.length === 0 ? (
-            <div className='rounded-2xl border border-dashed border-slate-600/80 px-4 py-10 text-center text-sm text-slate-500'>
+            <div className='rounded-2xl border border-dashed border-slate-600/80 px-4 py-10 text-center text-sm text-slate-400'>
               아직 댓글이 없습니다. 첫 댓글을 작성해보세요!
             </div>
           ) : (
@@ -656,7 +656,7 @@ export default function TaskDetailPage({ teamId, taskId }: TaskDetailPageProps) 
                     <textarea
                       value={editingContent}
                       onChange={e => setEditingContent(e.target.value)}
-                      className='w-full resize-none rounded-xl border border-white/10 bg-slate-900/60 p-3 text-sm text-white placeholder-slate-500 focus:border-sky-500/50 focus:outline-none focus:ring-2 focus:ring-sky-500/20'
+                      className='w-full resize-none rounded-xl border border-white/10 bg-slate-900/60 p-3 text-base text-white placeholder-slate-500 focus:border-sky-500/50 focus:outline-none focus:ring-2 focus:ring-sky-500/20'
                       rows={3}
                     />
                     <div className='mt-4 flex justify-end gap-2'>
@@ -685,11 +685,11 @@ export default function TaskDetailPage({ teamId, taskId }: TaskDetailPageProps) 
                         <span className='font-semibold text-sm text-white'>
                           {comment.userName || `사용자 ${comment.userId}`}
                         </span>
-                        <span className='text-xs text-slate-500'>·</span>
-                        <span className='text-xs text-slate-500'>
+                        <span className='text-xs text-slate-400'>·</span>
+                        <span className='text-xs text-slate-400'>
                           {formatCompactDateTime(comment.crtdAt)}
                         </span>
-                        {comment.mdfdAt && <span className='text-xs text-slate-500'>(수정됨)</span>}
+                        {comment.mdfdAt && <span className='text-xs text-slate-400'>(수정됨)</span>}
                       </div>
                       {currentUserId === comment.userId && comment.status !== 0 && (
                         <div className='flex items-center gap-1'>
@@ -714,7 +714,7 @@ export default function TaskDetailPage({ teamId, taskId }: TaskDetailPageProps) 
                     </div>
                     {/* 댓글 내용 */}
                     {comment.status === 0 ? (
-                      <p className='mt-2 text-sm italic text-slate-500'>삭제된 댓글입니다.</p>
+                      <p className='mt-2 text-sm italic text-slate-400'>삭제된 댓글입니다.</p>
                     ) : (
                       <p className='mt-2 text-sm leading-relaxed text-slate-300 whitespace-pre-wrap'>
                         {comment.commentContent}

--- a/src/app/teams/components/DateInfoInline.tsx
+++ b/src/app/teams/components/DateInfoInline.tsx
@@ -14,7 +14,7 @@ type DateInfoInlineProps = {
 
 const sizeStyles = {
   sm: {
-    container: "text-[0.65rem] text-slate-500",
+    container: "text-[0.65rem] text-slate-400",
     icon: "w-3 h-3",
     iconGap: "gap-1",
     divider: "text-slate-600",

--- a/src/app/teams/components/EmptyState.tsx
+++ b/src/app/teams/components/EmptyState.tsx
@@ -46,7 +46,7 @@ export function EmptyState({
       )}
       <p className="text-sm font-medium text-slate-400">{message}</p>
       {description && (
-        <p className="mt-1 text-xs text-slate-500">{description}</p>
+        <p className="mt-1 text-xs text-slate-400">{description}</p>
       )}
       {action && <div className="mt-4">{action}</div>}
     </div>

--- a/src/app/teams/components/SectionLabel.tsx
+++ b/src/app/teams/components/SectionLabel.tsx
@@ -2,7 +2,7 @@ type SectionLabelProps = {
   children: React.ReactNode;
   /** 자간 간격: tight(0.4em), normal(0.6em), wide(0.7em) */
   spacing?: "tight" | "normal" | "wide";
-  /** 텍스트 색상: muted(slate-400), subtle(slate-500) */
+  /** 텍스트 색상: muted(slate-400), subtle(slate-400) */
   color?: "muted" | "subtle";
 };
 
@@ -14,7 +14,7 @@ const spacingStyles = {
 
 const colorStyles = {
   muted: "text-slate-400",
-  subtle: "text-slate-500",
+  subtle: "text-slate-400",
 } as const;
 
 /**

--- a/src/app/teams/components/TaskForm.tsx
+++ b/src/app/teams/components/TaskForm.tsx
@@ -136,7 +136,7 @@ export function TaskForm({
         </div>
       </div>
 
-      <div className="flex flex-col-reverse justify-end gap-2 pt-2">
+      <div className="flex flex-col justify-end gap-2 pt-2">
         {cancelHref ? (
           <ButtonLink href={cancelHref} variant="secondary">
             취소


### PR DESCRIPTION
- 보조 텍스트 색상 대비 개선 (text-slate-500 → text-slate-400, 23개 파일)
- iOS Safari 입력 자동 확대 방지 (input/textarea/select 16px 이상 적용)
  - TaskDetailPage 댓글 작성/수정 textarea
  - TaskFilters 검색 input + 담당자 select
  - InviteModal 만료일 select + 사용 횟수 input
  - DiscordSection Webhook URL input
- TaskFilters "내 태스크" 버튼 글씨 크기 통일 (담당자 select와 일치)
- TaskForm 버튼 순서 표준화 (취소 → 완료, flex-col-reverse 제거)