### PR TITLE
fix: 타임존 로컬 표시 전환 — UTC 메서드 → 로컬 메서드 전면 교체

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Next.js 15 App Router + Bun 팀 협업/태스크 관리 웹앱.
 
 ## Conventions
 - 한국어 UI (라벨, 에러 메시지, 토스트 모두 한국어)
-- 날짜: UTC 저장, UTC 표시 (타임존 변환 절대 하지 않음)
+- 날짜: UTC 저장, 로컬 표시 (DB는 UTC, 브라우저에서 로컬 타임존으로 변환하여 표시)
 - iOS Safari: `backdrop-filter:blur()` 사용 금지 → `box-shadow`로 대체
 - glass-morphism: `bg-slate-800/50 border-slate-700/50`
 - 태스크 상태 추가/변경 시 `src/app/config/taskStatusConfig.ts` 참조

--- a/src/app/components/CalendarView.tsx
+++ b/src/app/components/CalendarView.tsx
@@ -330,7 +330,7 @@ export function CalendarView({ tasks, teamId }: CalendarViewProps) {
                   const dayTasks = singleDayTasksByDate.get(dateKey) || [];
                   const isToday = dateKey === todayKey;
                   const isWeekend = isWeekendDate(date);
-                  const isCurrentMonth = date.getUTCMonth() === month;
+                  const isCurrentMonth = date.getMonth() === month;
 
                   return (
                     <div
@@ -345,14 +345,14 @@ export function CalendarView({ tasks, teamId }: CalendarViewProps) {
                           className={`inline-flex h-6 w-6 items-center justify-center rounded-full text-xs ${
                             isToday
                               ? 'bg-sky-500 font-bold text-white'
-                              : date.getUTCDay() === 0
+                              : date.getDay() === 0
                                 ? 'text-red-400'
-                                : date.getUTCDay() === 6
+                                : date.getDay() === 6
                                   ? 'text-sky-400'
                                   : 'text-slate-400'
                           }`}
                         >
-                          {date.getUTCDate()}
+                          {date.getDate()}
                         </span>
                         {/* +n more 버튼 - 태스크가 2개 초과하거나 멀티데이 바가 있을 때 */}
                         {(dayTasks.length > 2 || (hasMoreBars && dayIdx === 6)) && (
@@ -483,7 +483,7 @@ export function CalendarView({ tasks, teamId }: CalendarViewProps) {
           {/* 팝오버 헤더 */}
           <div className="sticky top-0 flex items-center justify-between border-b border-white/10 bg-slate-800/95 px-3 py-2">
             <span className="text-sm font-semibold text-white">
-              {popover.date ? `${popover.date.getUTCMonth() + 1}월 ${popover.date.getUTCDate()}일` : ''}
+              {popover.date ? `${popover.date.getMonth() + 1}월 ${popover.date.getDate()}일` : ''}
             </span>
             <button
               onClick={() => setPopover(prev => ({ ...prev, isOpen: false }))}

--- a/src/app/components/GanttChart.tsx
+++ b/src/app/components/GanttChart.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import type { Task } from '../types/task';
 import { deadlineStyles, formatDateDisplay, getTaskDeadlineInfo } from '../utils/taskUtils';
-import { daysBetween, generateDateRange, isToday, isWeekend, getLocalTodayAsUTC } from '../utils/dateUtils';
+import { daysBetween, generateDateRange, isToday, isWeekend, getToday } from '../utils/dateUtils';
 import { getStatusMeta, getStatusColors, getStatusTextColor } from '../config/taskStatusConfig';
 import { EmptyState } from '../teams/components';
 import { viewContainerStyles } from '@/styles/teams';
@@ -36,9 +36,9 @@ export function GanttChart({ tasks, teamId }: GanttChartProps) {
     const allTasks = sortedTasks.withStartDate;
     if (allTasks.length === 0) {
       // 기본값: 오늘부터 14일 (로컬 "오늘"을 UTC 자정으로 변환)
-      const today = getLocalTodayAsUTC();
+      const today = getToday();
       const twoWeeksLater = new Date(today);
-      twoWeeksLater.setUTCDate(today.getUTCDate() + 13);
+      twoWeeksLater.setDate(today.getDate() + 13);
       return generateDateRange(today, twoWeeksLater);
     }
 
@@ -55,13 +55,13 @@ export function GanttChart({ tasks, teamId }: GanttChartProps) {
     });
 
     // 앞뒤로 여유 추가 (3일씩, UTC 기준)
-    minDate.setUTCDate(minDate.getUTCDate() - 3);
-    maxDate.setUTCDate(maxDate.getUTCDate() + 3);
+    minDate.setDate(minDate.getDate() - 3);
+    maxDate.setDate(maxDate.getDate() + 3);
 
     // 최소 14일 보장
     const days = daysBetween(minDate, maxDate);
     if (days < 14) {
-      maxDate.setUTCDate(maxDate.getUTCDate() + (14 - days));
+      maxDate.setDate(maxDate.getDate() + (14 - days));
     }
 
     return generateDateRange(minDate, maxDate);
@@ -183,7 +183,7 @@ export function GanttChart({ tasks, teamId }: GanttChartProps) {
                             width: Math.max(barStyle.width - 4, 20),
                           }}
                           onClick={() => handleTaskClick(task.taskId)}
-                          title={`${task.taskName}\n${task.startAt ? new Date(task.startAt).toLocaleDateString('ko-KR', { timeZone: 'UTC' }) : ''} ~ ${task.endAt ? new Date(task.endAt).toLocaleDateString('ko-KR', { timeZone: 'UTC' }) : ''}`}
+                          title={`${task.taskName}\n${task.startAt ? new Date(task.startAt).toLocaleDateString('ko-KR') : ''} ~ ${task.endAt ? new Date(task.endAt).toLocaleDateString('ko-KR') : ''}`}
                         >
                           <span className="absolute inset-0 flex items-center justify-center overflow-hidden px-2 text-[10px] font-semibold text-white drop-shadow truncate">
                             {task.taskName}

--- a/src/app/teams/[teamId]/components/TeamManagementSection.tsx
+++ b/src/app/teams/[teamId]/components/TeamManagementSection.tsx
@@ -75,13 +75,11 @@ type TabConfig = {
   visible: boolean;
 };
 
-// 날짜 포맷 헬퍼 함수 (UTC 기준)
 function formatMemberDate(date: Date) {
   return new Date(date).toLocaleDateString('ko-KR', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
-    timeZone: 'UTC',
   });
 }
 

--- a/src/app/utils/dateUtils.ts
+++ b/src/app/utils/dateUtils.ts
@@ -2,14 +2,13 @@
  * 날짜 관련 유틸리티 함수
  * GanttChart, CalendarView 등에서 공통으로 사용
  *
- * 모든 날짜는 UTC 기준으로 처리됩니다.
- * DB에서 UTC로 저장된 날짜를 로컬 타임존 변환 없이 정확히 표시하기 위함입니다.
+ * DB에서 UTC로 저장된 날짜를 브라우저 로컬 타임존으로 변환하여 표시합니다.
  */
 
 // ==================== 날짜 계산 함수 ====================
 
 /**
- * 두 날짜 사이의 일수 계산 (UTC 기준)
+ * 두 날짜 사이의 일수 계산 (로컬 기준)
  * @param start 시작 날짜
  * @param end 종료 날짜
  * @returns 일수 (음수 가능)
@@ -17,49 +16,49 @@
 export function daysBetween(start: Date, end: Date): number {
   const s = new Date(start);
   const e = new Date(end);
-  const startTime = Date.UTC(s.getUTCFullYear(), s.getUTCMonth(), s.getUTCDate());
-  const endTime = Date.UTC(e.getUTCFullYear(), e.getUTCMonth(), e.getUTCDate());
+  const startTime = new Date(s.getFullYear(), s.getMonth(), s.getDate()).getTime();
+  const endTime = new Date(e.getFullYear(), e.getMonth(), e.getDate()).getTime();
   return Math.ceil((endTime - startTime) / (1000 * 60 * 60 * 24));
 }
 
 /**
- * 날짜 범위 생성 (UTC 기준, start ~ end 포함)
+ * 날짜 범위 생성 (로컬 기준, start ~ end 포함)
  * @param start 시작 날짜
  * @param end 종료 날짜
- * @returns Date 배열 (UTC 자정 기준)
+ * @returns Date 배열 (로컬 자정 기준)
  */
 export function generateDateRange(start: Date, end: Date): Date[] {
   const dates: Date[] = [];
   const current = new Date(start);
-  current.setUTCHours(0, 0, 0, 0);
+  current.setHours(0, 0, 0, 0);
   const endDate = new Date(end);
-  endDate.setUTCHours(0, 0, 0, 0);
+  endDate.setHours(0, 0, 0, 0);
 
   while (current <= endDate) {
     dates.push(new Date(current));
-    current.setUTCDate(current.getUTCDate() + 1);
+    current.setDate(current.getDate() + 1);
   }
   return dates;
 }
 
 /**
- * 날짜를 UTC 자정(00:00:00)으로 정규화
+ * 날짜를 로컬 자정(00:00:00)으로 정규화
  * @param date 정규화할 날짜
- * @returns UTC 자정으로 설정된 새 Date 객체
+ * @returns 로컬 자정으로 설정된 새 Date 객체
  */
 export function normalizeDate(date: Date): Date {
   const normalized = new Date(date);
-  normalized.setUTCHours(0, 0, 0, 0);
+  normalized.setHours(0, 0, 0, 0);
   return normalized;
 }
 
 /**
- * 로컬 "오늘"을 UTC 자정 Date 객체로 반환
+ * 로컬 "오늘"을 자정 Date 객체로 반환
  * 캘린더/간트 차트에서 "오늘" 기준 날짜 생성 시 사용
  */
-export function getLocalTodayAsUTC(): Date {
+export function getToday(): Date {
   const now = new Date();
-  return new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate());
 }
 
 /**
@@ -82,9 +81,9 @@ export const DEFAULT_START_TIME = '00:00';
 export const DEFAULT_END_TIME = '23:59';
 
 /**
- * 날짜(YYYY-MM-DD) + 시간(HH:MM) → ISO datetime 문자열 조합 (UTC)
+ * 날짜(YYYY-MM-DD) + 시간(HH:MM) → ISO datetime 문자열 조합
+ * 브라우저가 로컬(KST)로 해석 후 UTC 변환하여 ISO 문자열로 반환
  * 시작일: 초는 항상 :00, 종료일: 초는 항상 :59
- * Z suffix 필수 — 백엔드가 new Date()로 파싱할 때 서버 타임존 무관하게 UTC 보장
  */
 export function buildTaskDatetime(
   date: string,
@@ -94,64 +93,68 @@ export function buildTaskDatetime(
   if (!date) return null;
   const t = time || (type === 'start' ? DEFAULT_START_TIME : DEFAULT_END_TIME);
   const seconds = type === 'start' ? '00' : '59';
-  return `${date}T${t}:${seconds}Z`;
+  return new Date(`${date}T${t}:${seconds}`).toISOString();
 }
 
 /**
- * ISO datetime 또는 Date → 날짜(YYYY-MM-DD) + 시간(HH:MM) 분리
+ * ISO datetime 또는 Date → 날짜(YYYY-MM-DD) + 시간(HH:MM) 분리 (로컬 기준)
  */
 export function parseTaskDatetime(value: Date | string | null | undefined): { date: string; time: string } {
   if (!value) return { date: '', time: '' };
   const d = value instanceof Date ? value : new Date(value);
   if (isNaN(d.getTime())) return { date: '', time: '' };
-  const iso = d.toISOString();
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  const hours = String(d.getHours()).padStart(2, '0');
+  const minutes = String(d.getMinutes()).padStart(2, '0');
   return {
-    date: iso.split('T')[0],
-    time: iso.slice(11, 16),
+    date: `${year}-${month}-${day}`,
+    time: `${hours}:${minutes}`,
   };
 }
 
 // ==================== 캘린더 관련 함수 ====================
 
 /**
- * 월의 첫 날과 마지막 날 계산 (UTC 기준)
+ * 월의 첫 날과 마지막 날 계산 (로컬 기준)
  * @param year 연도
  * @param month 월 (0-11)
  */
 export function getMonthDays(year: number, month: number): { firstDay: Date; lastDay: Date } {
-  const firstDay = new Date(Date.UTC(year, month, 1));
-  const lastDay = new Date(Date.UTC(year, month + 1, 0));
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
   return { firstDay, lastDay };
 }
 
 /**
- * 캘린더 그리드 생성 (6주 = 42일 고정, UTC 기준)
+ * 캘린더 그리드 생성 (6주 = 42일 고정, 로컬 기준)
  * @param year 연도
  * @param month 월 (0-11)
- * @returns Date 배열 (이전달, 현재달, 다음달 날짜 포함, 모두 UTC 자정)
+ * @returns Date 배열 (이전달, 현재달, 다음달 날짜 포함, 모두 로컬 자정)
  */
 export function generateCalendarGrid(year: number, month: number): Date[] {
   const { firstDay, lastDay } = getMonthDays(year, month);
-  const startDayOfWeek = firstDay.getUTCDay();
-  const daysInMonth = lastDay.getUTCDate();
+  const startDayOfWeek = firstDay.getDay();
+  const daysInMonth = lastDay.getDate();
 
   const grid: Date[] = [];
 
   // 이전 달의 날짜
-  const prevMonthLastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const prevMonthLastDay = new Date(year, month, 0).getDate();
   for (let i = startDayOfWeek - 1; i >= 0; i--) {
-    grid.push(new Date(Date.UTC(year, month - 1, prevMonthLastDay - i)));
+    grid.push(new Date(year, month - 1, prevMonthLastDay - i));
   }
 
   // 현재 달의 날짜
   for (let day = 1; day <= daysInMonth; day++) {
-    grid.push(new Date(Date.UTC(year, month, day)));
+    grid.push(new Date(year, month, day));
   }
 
   // 다음 달의 날짜 (6주 고정)
   let nextDay = 1;
   while (grid.length < 42) {
-    grid.push(new Date(Date.UTC(year, month + 1, nextDay++)));
+    grid.push(new Date(year, month + 1, nextDay++));
   }
 
   return grid;
@@ -176,26 +179,26 @@ export function splitIntoWeeks<T>(grid: T[]): T[][] {
 export const WEEKDAYS_KO = ['일', '월', '화', '수', '목', '금', '토'] as const;
 
 /**
- * 주말 여부 확인 (UTC 기준)
+ * 주말 여부 확인 (로컬 기준)
  * @param date Date 객체
  * @returns 주말(토, 일)이면 true
  */
 export function isWeekend(date: Date): boolean {
-  const day = date.getUTCDay();
+  const day = date.getDay();
   return day === 0 || day === 6;
 }
 
 /**
  * 오늘인지 확인
- * 입력 날짜의 UTC 날짜가 로컬 "오늘"과 같은지 비교
- * @param date 확인할 날짜 (UTC 기준)
+ * 입력 날짜의 로컬 날짜가 로컬 "오늘"과 같은지 비교
+ * @param date 확인할 날짜
  * @returns 오늘이면 true
  */
 export function isToday(date: Date): boolean {
   const now = new Date();
   return (
-    date.getUTCFullYear() === now.getFullYear() &&
-    date.getUTCMonth() === now.getMonth() &&
-    date.getUTCDate() === now.getDate()
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate()
   );
 }

--- a/src/app/utils/taskUtils.ts
+++ b/src/app/utils/taskUtils.ts
@@ -36,8 +36,7 @@ export function getDeadlineStatus(endAt: Date | null): DeadlineStatus {
   const end = new Date(endAt);
   // "오늘"은 사용자의 로컬 타임존 기준
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  // endAt의 날짜는 UTC 컴포넌트에서 추출 (타임존 변환 방지)
-  const endDate = new Date(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate());
+  const endDate = new Date(end.getFullYear(), end.getMonth(), end.getDate());
 
   const diffDays = Math.ceil((endDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
 
@@ -121,7 +120,7 @@ function getDaysFromNow(date: Date): number {
   const now = new Date();
   const target = new Date(date);
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const targetDate = new Date(target.getUTCFullYear(), target.getUTCMonth(), target.getUTCDate());
+  const targetDate = new Date(target.getFullYear(), target.getMonth(), target.getDate());
   return Math.ceil((targetDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
 }
 
@@ -201,9 +200,8 @@ export function filterByPeriod(tasks: Task[], period: PeriodFilter): Task[] {
     if (!task.endAt && period !== 'overdue') return false;
 
     const endDate = task.endAt ? new Date(task.endAt) : null;
-    // endAt의 날짜는 UTC 컴포넌트에서 추출 (타임존 변환 방지)
     const endDateOnly = endDate
-      ? new Date(endDate.getUTCFullYear(), endDate.getUTCMonth(), endDate.getUTCDate())
+      ? new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate())
       : null;
 
     switch (period) {
@@ -280,9 +278,9 @@ export function getUniqueAssignees(tasks: Task[]): { id: number; name: string }[
  */
 export function formatCompactDateTime(date: Date): string {
   const d = new Date(date);
-  const hours = d.getUTCHours().toString().padStart(2, '0');
-  const minutes = d.getUTCMinutes().toString().padStart(2, '0');
-  return `${d.getUTCMonth() + 1}/${d.getUTCDate()} ${hours}:${minutes}`;
+  const hours = d.getHours().toString().padStart(2, '0');
+  const minutes = d.getMinutes().toString().padStart(2, '0');
+  return `${d.getMonth() + 1}/${d.getDate()} ${hours}:${minutes}`;
 }
 
 /**
@@ -298,7 +296,6 @@ export function formatShortDate(date: Date | null): string | null {
   return d.toLocaleDateString('ko-KR', {
     month: 'short',
     day: 'numeric',
-    timeZone: 'UTC',
   });
 }
 
@@ -315,7 +312,6 @@ export function formatDateWithYear(date: Date | null): string {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
-    timeZone: 'UTC',
   });
 }
 
@@ -335,7 +331,6 @@ export function formatFullDateTime(date: Date | null): string | null {
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,
-    timeZone: 'UTC',
   });
 }
 
@@ -347,7 +342,10 @@ export function formatFullDateTime(date: Date | null): string | null {
  * @example formatDateKey(new Date('2024-01-15')) // "2024-01-15"
  */
 export function formatDateKey(date: Date): string {
-  return date.toISOString().split('T')[0];
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }
 
 /**
@@ -358,5 +356,5 @@ export function formatDateKey(date: Date): string {
  * @example formatDateDisplay(new Date('2024-01-15')) // "1/15"
  */
 export function formatDateDisplay(date: Date): string {
-  return `${date.getUTCMonth() + 1}/${date.getUTCDate()}`;
+  return `${date.getMonth() + 1}/${date.getDate()}`;
 }


### PR DESCRIPTION
- dateUtils: getUTC* → get*, setUTC* → set*, Date.UTC → new Date(), getLocalTodayAsUTC → getToday
- buildTaskDatetime: Z suffix → new Date(local).toISOString() (KST→UTC 변환)
- parseTaskDatetime: toISOString 기반 → 로컬 컴포넌트 추출
- taskUtils: getUTC* → get*, timeZone:'UTC' 제거, formatDateKey 로컬 포맷
- CalendarView: getUTCMonth/Day/Date → getMonth/Day/Date (5곳)
- GanttChart: setUTCDate → setDate, timeZone:'UTC' 제거 (6곳)
- TeamManagementSection: formatMemberDate timeZone:'UTC' 제거
- CLAUDE.md: "UTC 저장, 로컬 표시" 컨벤션 반영