### PR TITLE
feat: Swarm 스택 마이그레이션 — prod_next 스택 YAML + CI/CD 개편

### DIFF
--- a/.github/workflows/oci_build_and_deploy_next.yml
+++ b/.github/workflows/oci_build_and_deploy_next.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -20,26 +24,42 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set short SHA
+        id: sha
+        run: echo "short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+
       - name: Build and Push arm64 image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: ${{ secrets.REGISTRY_URL }}/sys_next:latest
+          tags: ${{ secrets.REGISTRY_URL }}/prod_next:${{ steps.sha.outputs.short }}
           provenance: false
           sbom: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy via SSH to Docker Swarm
+      - name: Rsync stack YAML to Swarm manager
+        run: |
+          echo "${{ secrets.SWARM_MANAGER_SSH_KEY }}" > /tmp/ssh_key
+          chmod 600 /tmp/ssh_key
+          rsync -avz \
+            -e "ssh -i /tmp/ssh_key -o StrictHostKeyChecking=no" \
+            infra/docker-stack.app.yml \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_SERVER }}:/home/ubuntu/desktop/deploy/infra/prod_next.yml
+          rm /tmp/ssh_key
+
+      - name: Deploy stack via SSH
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.DEPLOY_SERVER }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.SWARM_MANAGER_SSH_KEY }}
           script: |
-            ENV_PATH="/home/ubuntu/desktop/deploy/sys/config/env/.env"
-            docker service update \
-            --with-registry-auth \
-            $(grep -vE '^#|^$' $ENV_PATH | awk '{print "--env-add", $0}') \
-            --image ${{ secrets.REGISTRY_URL }}/sys_next:latest sys_next
+            export REGISTRY_URL=${{ secrets.REGISTRY_URL }}
+            export IMAGE_TAG=${{ steps.sha.outputs.short }}
+            docker stack deploy \
+              -c /home/ubuntu/desktop/deploy/infra/prod_next.yml \
+              --with-registry-auth \
+              prod_next
+            docker stack services prod_next

--- a/infra/docker-stack.app.yml
+++ b/infra/docker-stack.app.yml
@@ -1,0 +1,46 @@
+version: '3.9'
+
+services:
+  app:
+    image: ${REGISTRY_URL}/prod_next:${IMAGE_TAG}
+    networks:
+      - sys_default
+    env_file:
+      - /home/ubuntu/desktop/deploy/sys/config/env/.env
+    ports:
+      - target: 3000
+        published: 23000
+        mode: ingress
+    healthcheck:
+      test:
+        - CMD
+        - bun
+        - -e
+        - "fetch('http://localhost:3000/api/health').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))"
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    deploy:
+      replicas: 20
+      placement:
+        constraints:
+          - node.labels.prod_next == 1
+      update_config:
+        parallelism: 1
+        order: start-first
+        failure_action: rollback
+        monitor: 10s
+        max_failure_ratio: 0
+      rollback_config:
+        parallelism: 1
+        order: start-first
+        failure_action: pause
+        monitor: 5s
+        max_failure_ratio: 0
+      restart_policy:
+        condition: on-failure
+
+networks:
+  sys_default:
+    external: true


### PR DESCRIPTION
- infra/docker-stack.app.yml 신규: prod_next 스택 YAML
  - env_file로 백엔드와 공유된 .env 주입 (/home/ubuntu/desktop/deploy/sys/config/env/.env)
  - Bun 내장 fetch로 healthcheck (/api/health, curl 의존성 없음)
  - sys_next inspect와 1:1 대조 검증 완료 (Replicas 20, Port 23000→3000 ingress, update/rollback 일치)

- .github/workflows/oci_build_and_deploy_next.yml: docker service update → docker stack deploy 전환
  - 이미지 태그 sys_next:latest → prod_next:{short_sha} (git SHA 7자)
  - rsync로 스택 YAML 서버 전송 (/home/ubuntu/desktop/deploy/infra/prod_next.yml) 후 docker stack deploy
  - paths-ignore 추가 (docs/**, *.md)
  - workflow_dispatch 추가 (수동 실행 가능)
  - Runner는 ubuntu-24.04-arm 유지 (fs-01 배치이므로 ARM native 빌드 이점)

⚠️ 파일 준비 단계. 실제 마이그레이션은 백엔드 레포의 docs/tasks-swarm-stack-migration.md Phase 0~7 수동 실행 필요.