### PR TITLE
fix(healthcheck): Bun fetch 타이밍/IPv6 이슈 해결 — 127.0.0.1 + top-level await

### DIFF
--- a/infra/docker-stack.app.yml
+++ b/infra/docker-stack.app.yml
@@ -16,11 +16,11 @@ services:
         - CMD
         - bun
         - -e
-        - "fetch('http://localhost:3000/api/health').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))"
+        - "const r = await fetch('http://127.0.0.1:3000/api/health'); process.exit(r.ok?0:1)"
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 60s
     deploy:
       replicas: 20
       placement:


### PR DESCRIPTION
prod_next_app 20 replicas 전부 "finished" (exit 0) 로 종료되는 문제. Next.js는 정상 기동("Ready in XXXms") 됐지만 Swarm healthcheck가 실패 판정 → SIGTERM → graceful shutdown → exit 0 → max_failure_ratio:0 rollback 루프 → 0/20 고착.

원인:
- Bun의 `localhost` fetch가 IPv6 우선 시도하며 컨테이너에서 실패 가능
- Promise chain의 process.exit 타이밍 이슈 (Bun event loop)

수정:
- URL: `http://localhost:3000` → `http://127.0.0.1:3000` (IPv4 명시)
- 실행: `.then().catch()` → top-level await (Bun 안정성)
- start_period: 40s → 60s (20 replicas 동시 기동 부하 여유)

검증: 단일 컨테이너 docker run 시 Up 유지 + "Ready in 121ms" 정상 확인