### PR TITLE
feat(team): 보관함·활성 탭 UX 개선 및 실시간 동기화 강화

### DIFF
--- a/src/app/teams/[teamId]/TeamBoard.tsx
+++ b/src/app/teams/[teamId]/TeamBoard.tsx
@@ -100,7 +100,6 @@ export default function TeamBoard({ teamId }: TeamBoardProps) {
 
   // 데이터 탭: 활성 / 보관함
   const [dataTab, setDataTab] = useState<DataTab>('active');
-  const [archiveCount, setArchiveCount] = useState(0);
 
   // 튜토리얼 가이드 상태
   const [showTutorial, setShowTutorial] = useState(false);
@@ -155,6 +154,26 @@ export default function TeamBoard({ teamId }: TeamBoardProps) {
       return newTasks;
     });
   }, []);
+
+  // 태스크 분류 공통 함수
+  const classifyTasks = useCallback((taskList: Task[]) => {
+    const classified: Record<ColumnKey, Task[]> = {
+      todo: [], inProgress: [], done: [], onHold: [], cancelled: [],
+    };
+    taskList.forEach(task => {
+      const columnKey = taskStatusToColumn[task.taskStatus] || 'todo';
+      classified[columnKey].push(task);
+    });
+    return classified;
+  }, []);
+
+  // 태스크 목록 조회 (현재 탭 API 1회만 호출)
+  const fetchAndSetTasks = useCallback(async (accessToken: string, tab: DataTab) => {
+    const actStatusParam = tab === 'archive' ? 0 : 1;
+    const tasksResponse = await getTeamTasks(teamIdNum, accessToken, actStatusParam);
+    setTasks(classifyTasks(tasksResponse.data.tasks));
+    return tasksResponse;
+  }, [teamIdNum, classifyTasks]);
 
   // ===== WebSocket (Context에서 관리) =====
   const { socket, onlineUsers } = useTeamSocketContext();
@@ -272,12 +291,42 @@ export default function TeamBoard({ teamId }: TeamBoardProps) {
     toast.success('태스크 상태가 변경되었습니다.');
   }, []);
 
-  const handleSocketTaskActiveStatusChanged = useCallback((payload: TaskActiveStatusChangedPayload) => {
-    if (payload.newActStatus === 0) {
-      removeTaskFromLocal(payload.taskId);
-      toast.success('태스크가 비활성화되었습니다.');
-    }
-  }, [removeTaskFromLocal]);
+  // 연속 active-status 이벤트에 대한 리페치 debounce (서버 부하 방지)
+  const activeStatusRefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    if (activeStatusRefetchTimerRef.current) clearTimeout(activeStatusRefetchTimerRef.current);
+  }, []);
+
+  const handleSocketTaskActiveStatusChanged = useCallback(
+    (payload: TaskActiveStatusChangedPayload) => {
+      const currentTabActStatus = dataTab === 'active' ? 1 : 0;
+      const nowMatchesCurrentTab = payload.newActStatus === currentTabActStatus;
+
+      if (nowMatchesCurrentTab) {
+        // 현재 탭에 새로 포함되어야 할 태스크: 전체 객체가 필요하므로 리페치 (debounce)
+        if (activeStatusRefetchTimerRef.current) {
+          clearTimeout(activeStatusRefetchTimerRef.current);
+        }
+        activeStatusRefetchTimerRef.current = setTimeout(() => {
+          if (!session?.user?.accessToken) return;
+          fetchAndSetTasks(session.user.accessToken, dataTab).catch(err => {
+            console.error('Failed to refresh tasks on active-status change:', err);
+            toast.error('태스크 목록 갱신에 실패했습니다.');
+          });
+        }, 300);
+      } else {
+        // 현재 탭에서 벗어난 태스크: 로컬 제거
+        removeTaskFromLocal(payload.taskId);
+      }
+
+      // 토스트 id 지정 → 연속 이벤트 시 스팸 없이 마지막 내용만 표시
+      toast.success(
+        payload.newActStatus === 0 ? '태스크가 보관되었습니다.' : '태스크가 복원되었습니다.',
+        { id: 'task-active-status' },
+      );
+    },
+    [dataTab, removeTaskFromLocal, session?.user?.accessToken, fetchAndSetTasks],
+  );
 
   // 온라인 유저 접속 이벤트 (토스트 알림만 - 상태는 Context에서 관리)
   const handleUserJoined = useCallback((payload: UserJoinedPayload) => {
@@ -387,33 +436,6 @@ export default function TeamBoard({ teamId }: TeamBoardProps) {
   useEffect(() => {
     fetchInvitesRef.current = fetchInvites;
   }, [fetchInvites]);
-
-  // 태스크 분류 공통 함수
-  const classifyTasks = useCallback((taskList: Task[]) => {
-    const classified: Record<ColumnKey, Task[]> = {
-      todo: [], inProgress: [], done: [], onHold: [], cancelled: [],
-    };
-    taskList.forEach(task => {
-      const columnKey = taskStatusToColumn[task.taskStatus] || 'todo';
-      classified[columnKey].push(task);
-    });
-    return classified;
-  }, []);
-
-  // 태스크 목록 조회 + 보관함 카운트 갱신 공통 함수
-  const fetchAndSetTasks = useCallback(async (accessToken: string, tab: DataTab) => {
-    const actStatusParam = tab === 'archive' ? 0 : 1;
-    const tasksResponse = await getTeamTasks(teamIdNum, accessToken, actStatusParam);
-    setTasks(classifyTasks(tasksResponse.data.tasks));
-
-    if (tab === 'active') {
-      getTeamTasks(teamIdNum, accessToken, 0)
-        .then(res => setArchiveCount(res.data.tasks.length))
-        .catch(() => setArchiveCount(0));
-    }
-
-    return tasksResponse;
-  }, [teamIdNum, classifyTasks]);
 
   // 초기 로딩: 팀 정보 + 멤버 + 통합 + 태스크 (페이지 진입 시 1회)
   useEffect(() => {
@@ -740,7 +762,6 @@ export default function TeamBoard({ teamId }: TeamBoardProps) {
       try {
         await updateTaskActiveStatus(teamIdNum, taskId, 1, session.user.accessToken);
         removeTaskFromLocal(taskId);
-        setArchiveCount(prev => Math.max(0, prev - 1));
         toast.success('태스크가 활성으로 복원되었습니다.');
       } catch (err) {
         console.error('Failed to restore task:', err);
@@ -758,7 +779,6 @@ export default function TeamBoard({ teamId }: TeamBoardProps) {
       try {
         await updateTaskActiveStatus(teamIdNum, taskId, 0, session.user.accessToken);
         removeTaskFromLocal(taskId);
-        setArchiveCount(prev => prev + 1);
         toast.success('보관함으로 이동되었습니다.');
       } catch (err) {
         console.error('Failed to archive task:', err);
@@ -894,7 +914,6 @@ export default function TeamBoard({ teamId }: TeamBoardProps) {
           onViewModeChange={setViewMode}
           dataTab={dataTab}
           onDataTabChange={setDataTab}
-          archiveCount={archiveCount}
         />
 
         {/* 뷰 렌더링 - 로딩 시 스켈레톤 표시 */}

--- a/src/app/teams/[teamId]/components/ViewModeToggle.tsx
+++ b/src/app/teams/[teamId]/components/ViewModeToggle.tsx
@@ -10,7 +10,6 @@ type ViewModeToggleProps = {
   onViewModeChange: (mode: ViewMode) => void;
   dataTab: DataTab;
   onDataTabChange: (tab: DataTab) => void;
-  archiveCount?: number;
 };
 
 const viewModeConfig = [
@@ -25,7 +24,7 @@ const dataTabConfig: { key: DataTab; label: string; icon?: typeof ArchiveIcon }[
   { key: 'archive', label: '보관함', icon: ArchiveIcon },
 ];
 
-export function ViewModeToggle({ viewMode, onViewModeChange, dataTab, onDataTabChange, archiveCount }: ViewModeToggleProps) {
+export function ViewModeToggle({ viewMode, onViewModeChange, dataTab, onDataTabChange }: ViewModeToggleProps) {
   return (
     <div className="flex items-center justify-between mb-4">
       {/* 데이터 탭: 활성 / 보관함 */}
@@ -42,11 +41,6 @@ export function ViewModeToggle({ viewMode, onViewModeChange, dataTab, onDataTabC
           >
             {Icon && <Icon className="w-3.5 h-3.5" />}
             {label}
-            {key === 'archive' && archiveCount !== undefined && archiveCount > 0 && (
-              <span className="ml-1 px-1.5 py-0.5 text-[10px] rounded-full bg-slate-700 text-slate-300">
-                {archiveCount}
-              </span>
-            )}
           </button>
         ))}
       </div>

--- a/src/app/teams/[teamId]/tasks/[taskId]/TaskDetailPage.tsx
+++ b/src/app/teams/[teamId]/tasks/[taskId]/TaskDetailPage.tsx
@@ -32,13 +32,14 @@ import { StatusDropdown } from '@/app/components/StatusDropdown';
 import { ConfirmModal } from '@/app/components/ConfirmModal';
 import { EditIcon, TrashIcon, CommentIcon, SendIcon, ArchiveIcon, RestoreIcon } from '@/app/components/Icons';
 import { formatCompactDateTime } from '@/app/utils/taskUtils';
-import type { TaskStatusKey } from '@/app/config/taskStatusConfig';
+import { getStatusBorderClassName, type TaskStatusKey } from '@/app/config/taskStatusConfig';
 import { cardStyles } from '@/styles/teams';
 import { useTeamTaskId, useTeamSocketEvents } from '@/app/hooks';
 import { useTeamSocketContext } from '../../contexts';
 import type {
   TaskUpdatedPayload,
   TaskStatusChangedPayload,
+  TaskActiveStatusChangedPayload,
   CommentCreatedPayload,
   CommentUpdatedPayload,
   CommentDeletedPayload,
@@ -113,6 +114,20 @@ export default function TaskDetailPage({ teamId, taskId }: TaskDetailPageProps) 
         };
       });
       toast.success('태스크 상태가 변경되었습니다.');
+    },
+    [taskIdNum],
+  );
+
+  // Socket 이벤트 핸들러: 태스크 활성 상태 변경 (보관/복원)
+  const handleSocketTaskActiveStatusChanged = useCallback(
+    (payload: TaskActiveStatusChangedPayload) => {
+      if (payload.taskId !== taskIdNum) return;
+
+      setTaskDetail(prev => {
+        if (!prev) return prev;
+        return { ...prev, actStatus: payload.newActStatus };
+      });
+      toast.success(payload.newActStatus === 0 ? '태스크가 보관함으로 이동되었습니다.' : '태스크가 활성으로 복원되었습니다.');
     },
     [taskIdNum],
   );
@@ -193,6 +208,7 @@ export default function TaskDetailPage({ teamId, taskId }: TaskDetailPageProps) 
     {
       onTaskUpdated: handleSocketTaskUpdated,
       onTaskStatusChanged: handleSocketTaskStatusChanged,
+      onTaskActiveStatusChanged: handleSocketTaskActiveStatusChanged,
       onCommentCreated: handleSocketCommentCreated,
       onCommentUpdated: handleSocketCommentUpdated,
       onCommentDeleted: handleSocketCommentDeleted,
@@ -508,7 +524,7 @@ export default function TaskDetailPage({ teamId, taskId }: TaskDetailPageProps) 
       </div>
 
       {/* 태스크 상세 정보 */}
-      <section className={`${cardStyles.section} p-4`}>
+      <section className={`rounded-3xl border ${getStatusBorderClassName(taskDetail.taskStatus)} bg-slate-900/80 p-4 transition-colors`}>
         {isEditing ? (
           <>
             <div className='mb-4'>
@@ -535,7 +551,26 @@ export default function TaskDetailPage({ teamId, taskId }: TaskDetailPageProps) 
             {/* 헤더: 제목 + 작성자 + 수정 아이콘 */}
             <div className='flex items-start justify-between gap-3 mb-4'>
               <div className='flex-1 min-w-0'>
-                <h1 className='text-xl font-bold text-white break-words'>{taskDetail.taskName}</h1>
+                <div className='flex items-center gap-2 flex-wrap'>
+                  <h1 className='text-xl font-bold text-white break-words'>{taskDetail.taskName}</h1>
+                  <span
+                    className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium whitespace-nowrap ${
+                      taskDetail.actStatus === 1
+                        ? 'border-white/10 bg-slate-800/60 text-slate-200'
+                        : 'border-slate-500/30 bg-slate-800/40 text-slate-400'
+                    }`}
+                  >
+                    <span
+                      className={`inline-block w-1.5 h-1.5 rounded-full ${
+                        taskDetail.actStatus === 1
+                          ? 'bg-emerald-400 animate-pulse'
+                          : 'bg-slate-500'
+                      }`}
+                      aria-hidden='true'
+                    />
+                    {taskDetail.actStatus === 1 ? '활성' : '보관함'}
+                  </span>
+                </div>
                 <span className='mt-1 block text-xs text-slate-400'>
                   {taskDetail.userName || `사용자 ${taskDetail.crtdBy}`}
                 </span>


### PR DESCRIPTION
TeamBoard:
- 활성/보관 양방향 소켓 동기화 (기존엔 보관만 처리)
- 리페치 debounce(300ms) + toast id + error toast + unmount cleanup
- archiveCount 제거 → 현재 탭 API 1회만 호출 (병렬 호출 제거)

ViewModeToggle:
- archiveCount prop·뱃지 렌더 제거

TaskDetailPage:
- taskActiveStatusChanged 소켓 수신 핸들러 추가
- actStatus 배지(dot+pulse) — 활성/보관함 양쪽 표시
- 태스크 카드 테두리를 현재 taskStatus 색으로 (getStatusBorderClassName)