### PR TITLE
feat(team): 팀 단위 실시간 채팅 UI — 하단 바텀시트 (저장 없음)

### DIFF
--- a/src/app/teams/[teamId]/TeamBoard.tsx
+++ b/src/app/teams/[teamId]/TeamBoard.tsx
@@ -11,7 +11,7 @@ import { CalendarView } from '../../components/CalendarView';
 import { TaskFilters } from '../../components/TaskFilters';
 import { Kanban } from '../../components/Kanban';
 import { TeamsPageLayout, SectionLabel, ErrorAlert, TeamBoardSkeleton, ListViewSkeleton, Skeleton, FAB, IconButton } from '../components';
-import { EditIcon, UserGroupIcon, PlusIcon, QuestionMarkIcon } from '../../components/Icons';
+import { EditIcon, UserGroupIcon, PlusIcon, QuestionMarkIcon, CommentIcon } from '../../components/Icons';
 import { DropdownMenu } from './components/DropdownMenu';
 import type { Task } from '../../types/task';
 import { useTaskFilter, useTelegramLink, useDiscordLink, useTeamInvite, useTeamSocketEvents, useSafeNavigation } from '../../hooks';
@@ -29,7 +29,7 @@ import {
 } from '@/services/teamService';
 import { cardStyles } from '@/styles/teams';
 import { STATUS_TO_COLUMN, type ColumnKey } from '../../config/taskStatusConfig';
-import { TeamManagementSection, InviteModal, RoleChangeModal, ViewModeToggle, OnlineUsers, TutorialGuide, hasSeenTutorial, markTutorialSeen, type ViewMode, type DataTab } from './components';
+import { TeamManagementSection, InviteModal, RoleChangeModal, ViewModeToggle, OnlineUsers, TutorialGuide, hasSeenTutorial, markTutorialSeen, TeamChatPanel, type ViewMode, type DataTab } from './components';
 import { ROLES } from '../../config/roleConfig';
 import type {
   TaskCreatedPayload,
@@ -97,6 +97,9 @@ export default function TeamBoard({ teamId }: TeamBoardProps) {
 
   // 온라인 유저 모달 상태 (FAB 숨김용)
   const [isOnlineModalOpen, setIsOnlineModalOpen] = useState(false);
+
+  // 팀 채팅 바텀시트 상태
+  const [isChatOpen, setIsChatOpen] = useState(false);
 
   // 데이터 탭: 활성 / 보관함
   const [dataTab, setDataTab] = useState<DataTab>('active');
@@ -176,7 +179,7 @@ export default function TeamBoard({ teamId }: TeamBoardProps) {
   }, [teamIdNum, classifyTasks]);
 
   // ===== WebSocket (Context에서 관리) =====
-  const { socket, onlineUsers } = useTeamSocketContext();
+  const { socket, onlineUsers, emitChatMessage } = useTeamSocketContext();
 
   // Socket 이벤트 핸들러 (useCallback으로 메모이제이션)
   const handleSocketTaskCreated = useCallback(
@@ -828,6 +831,12 @@ export default function TeamBoard({ teamId }: TeamBoardProps) {
               </div>
               <div className="flex items-center gap-1 shrink-0">
                 <IconButton
+                  icon={CommentIcon}
+                  label="팀 채팅"
+                  variant="outlined"
+                  onClick={() => setIsChatOpen(true)}
+                />
+                <IconButton
                   icon={PlusIcon}
                   label="새 카드 작성"
                   variant="outlined"
@@ -961,8 +970,17 @@ export default function TeamBoard({ teamId }: TeamBoardProps) {
       {/* 튜토리얼 가이드 */}
       <TutorialGuide isOpen={showTutorial} onClose={handleCloseTutorial} />
 
-      {/* FAB: 새 카드 작성 (온라인 유저 모달이 열려있으면 숨김) */}
-      {!isOnlineModalOpen && <FAB href={`/teams/${teamId}/tasks/new`} label="새 카드 작성" />}
+      {/* 팀 채팅 바텀시트 (저장 없음, 실시간 브로드캐스트) */}
+      <TeamChatPanel
+        isOpen={isChatOpen}
+        onClose={() => setIsChatOpen(false)}
+        onSendMessage={emitChatMessage}
+        socket={socket}
+        currentUserId={session?.user?.userId}
+      />
+
+      {/* FAB: 새 카드 작성 (온라인 유저 모달/채팅이 열려있으면 숨김) */}
+      {!isOnlineModalOpen && !isChatOpen && <FAB href={`/teams/${teamId}/tasks/new`} label="새 카드 작성" />}
     </>
   );
 }

--- a/src/app/teams/[teamId]/components/TeamChatPanel.tsx
+++ b/src/app/teams/[teamId]/components/TeamChatPanel.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { CloseIcon, SendIcon } from '@/app/components/Icons';
+import type { TeamSocket, ChatReceivedPayload } from '@/types/socket';
+import { TeamSocketEvents } from '@/types/socket';
+
+/**
+ * 팀 채팅 메시지 (클라이언트 로컬 상태)
+ *
+ * 현재는 저장 없이 실시간 브로드캐스트만 하므로 새로고침 시 사라진다.
+ */
+interface TeamChatMessage {
+  id: string;
+  sender: string;
+  text: string;
+  timestamp: number;
+  isMine: boolean;
+}
+
+interface TeamChatPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** 메시지 전송 (Context의 emitChatMessage 주입). 생성된 clientMsgId 반환 */
+  onSendMessage: (text: string) => string | null;
+  socket?: TeamSocket | null;
+  currentUserId?: number;
+}
+
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' });
+}
+
+/**
+ * 팀 채팅 바텀시트
+ *
+ * - 하단에서 슬라이드업 (OnlineUsersModal과 동일 패턴, z-[100])
+ * - 저장 없음: 로컬 state로만 메시지 유지
+ * - self-filtering: 본인 메시지는 전송 시 로컬에 추가하고 서버 echo는 무시
+ */
+export function TeamChatPanel({ isOpen, onClose, onSendMessage, socket, currentUserId }: TeamChatPanelProps) {
+  const [messages, setMessages] = useState<TeamChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [hasNewMessage, setHasNewMessage] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isNearBottomRef = useRef(true);
+  const prevMessageCountRef = useRef(0);
+
+  /** 스크롤이 하단 근처인지 체크 */
+  const checkNearBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return true;
+    return el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+  }, []);
+
+  // 열릴 때 input 포커스 + 하단 스크롤
+  useEffect(() => {
+    if (isOpen) {
+      requestAnimationFrame(() => inputRef.current?.focus());
+      if (scrollRef.current) {
+        scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+      }
+      isNearBottomRef.current = true;
+      setHasNewMessage(false);
+    }
+  }, [isOpen]);
+
+  // 메시지 추가 시: 하단 근처면 자동 스크롤, 아니면 알림 표시
+  useEffect(() => {
+    if (messages.length <= prevMessageCountRef.current) {
+      prevMessageCountRef.current = messages.length;
+      return;
+    }
+    prevMessageCountRef.current = messages.length;
+    if (!isOpen) return;
+
+    if (isNearBottomRef.current && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    } else {
+      setHasNewMessage(true);
+    }
+  }, [isOpen, messages.length]);
+
+  // 채팅 수신 (본인 메시지는 전송 시 로컬에 추가했으므로 skip)
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleChatReceived = (payload: ChatReceivedPayload) => {
+      setMessages((prev) => {
+        // 이미 추가된 메시지(본인 로컬 추가분 또는 중복 수신)는 무시 — clientMsgId 기반 dedup
+        if (prev.some((m) => m.id === payload.messageId)) return prev;
+        return [
+          ...prev,
+          {
+            id: payload.messageId,
+            sender: payload.userName,
+            text: payload.message,
+            timestamp: new Date(payload.timestamp).getTime(),
+            isMine: currentUserId != null && payload.userId === currentUserId,
+          },
+        ];
+      });
+    };
+
+    socket.on(TeamSocketEvents.CHAT_RECEIVED, handleChatReceived);
+    return () => {
+      socket.off(TeamSocketEvents.CHAT_RECEIVED, handleChatReceived);
+    };
+  }, [socket, currentUserId]);
+
+  const handleSend = useCallback(() => {
+    const text = input.trim();
+    if (!text) return;
+
+    const clientMsgId = onSendMessage(text);
+    if (!clientMsgId) return;
+
+    // 서버 echo는 동일 clientMsgId로 dedup되므로 로컬에 즉시 추가 (낙관적 업데이트)
+    setMessages((prev) => [
+      ...prev,
+      { id: clientMsgId, sender: '나', text, timestamp: Date.now(), isMine: true },
+    ]);
+    setInput('');
+    inputRef.current?.focus();
+  }, [input, onSendMessage]);
+
+  const handleScroll = useCallback(() => {
+    isNearBottomRef.current = checkNearBottom();
+    if (isNearBottomRef.current) setHasNewMessage(false);
+  }, [checkNearBottom]);
+
+  const scrollToBottom = useCallback(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+    setHasNewMessage(false);
+    isNearBottomRef.current = true;
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+        e.preventDefault();
+        handleSend();
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    },
+    [handleSend, onClose],
+  );
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* 오버레이 - BottomNavBar(z-50) 위에 표시 */}
+      <div className="fixed inset-0 z-[100] bg-black/60" onClick={onClose} aria-hidden="true" />
+
+      {/* 바텀시트 */}
+      <div
+        className="fixed bottom-0 left-0 right-0 z-[100] animate-[slideUp_0.3s_ease-out]"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="team-chat-title"
+      >
+        <div className="mx-auto max-w-lg">
+          <div className="flex flex-col rounded-t-3xl border border-white/10 border-b-0 bg-slate-900 shadow-2xl">
+            {/* 드래그 핸들 */}
+            <div className="flex justify-center pt-3 pb-2">
+              <div className="w-10 h-1 rounded-full bg-slate-600" />
+            </div>
+
+            {/* 헤더 */}
+            <div className="flex items-center justify-between px-5 pb-3">
+              <h3 id="team-chat-title" className="text-lg font-bold text-white">
+                팀 채팅
+              </h3>
+              <button
+                onClick={onClose}
+                className="p-2 text-slate-400 hover:text-slate-200 hover:bg-white/5 rounded-full transition"
+                aria-label="닫기"
+              >
+                <CloseIcon className="w-5 h-5" />
+              </button>
+            </div>
+
+            {/* 메시지 목록 */}
+            <div className="relative">
+              <div
+                ref={scrollRef}
+                onScroll={handleScroll}
+                className="px-4 h-[40vh] overflow-y-auto space-y-2"
+              >
+                {messages.length === 0 ? (
+                  <div className="flex h-full items-center justify-center">
+                    <p className="text-sm text-slate-500">
+                      아직 메시지가 없습니다. 첫 메시지를 보내보세요!
+                    </p>
+                  </div>
+                ) : (
+                  messages.map((msg) => (
+                    <div
+                      key={msg.id}
+                      className={`flex flex-col ${msg.isMine ? 'items-end' : 'items-start'}`}
+                    >
+                      {!msg.isMine && (
+                        <span className="mb-0.5 text-xs font-medium text-cyan-400">{msg.sender}</span>
+                      )}
+                      <div
+                        className={`max-w-[75%] break-words rounded-2xl px-3 py-2 text-sm ${
+                          msg.isMine ? 'bg-cyan-600 text-white' : 'bg-slate-800 text-slate-200'
+                        }`}
+                      >
+                        {msg.text}
+                      </div>
+                      <span className="mt-0.5 text-[10px] text-slate-500">{formatTime(msg.timestamp)}</span>
+                    </div>
+                  ))
+                )}
+              </div>
+
+              {hasNewMessage && (
+                <button
+                  onClick={scrollToBottom}
+                  className="absolute bottom-2 left-1/2 -translate-x-1/2 animate-pulse rounded-full bg-cyan-600 px-3 py-1 text-xs text-white shadow-lg"
+                >
+                  ↓ 새 메시지
+                </button>
+              )}
+            </div>
+
+            {/* 입력 영역 - 하단 safe-area 고려 */}
+            <div className="flex items-center gap-2 border-t border-white/10 px-4 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom,0px))]">
+              <input
+                ref={inputRef}
+                type="text"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="메시지 입력..."
+                maxLength={200}
+                className="flex-1 rounded-full border border-slate-600/50 bg-slate-800 px-4 py-2 text-slate-200 placeholder:text-slate-500 focus:border-cyan-500/50 focus:outline-none"
+                style={{ fontSize: '16px' }}
+              />
+              <button
+                onClick={handleSend}
+                disabled={!input.trim()}
+                className="flex shrink-0 items-center justify-center rounded-full bg-cyan-600 p-2.5 text-white transition-colors hover:bg-cyan-500 disabled:bg-slate-700 disabled:text-slate-500"
+                aria-label="전송"
+              >
+                <SendIcon className="w-5 h-5" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/teams/[teamId]/components/index.ts
+++ b/src/app/teams/[teamId]/components/index.ts
@@ -5,3 +5,4 @@ export { TeamManagementSection } from './TeamManagementSection';
 export { ViewModeToggle, type ViewMode, type DataTab } from './ViewModeToggle';
 export { OnlineUsers } from './OnlineUsers';
 export { TutorialGuide, hasSeenTutorial, markTutorialSeen } from './TutorialGuide';
+export { TeamChatPanel } from './TeamChatPanel';

--- a/src/app/teams/[teamId]/contexts/TeamSocketContext.tsx
+++ b/src/app/teams/[teamId]/contexts/TeamSocketContext.tsx
@@ -34,6 +34,11 @@ interface TeamSocketContextValue {
   setOnlineUsers: React.Dispatch<React.SetStateAction<OnlineUserInfo[]>>;
   /** 수동 재연결 */
   reconnect: () => void;
+  /**
+   * 채팅 메시지 전송 (저장 없음, 실시간 브로드캐스트)
+   * @returns 생성된 clientMsgId (전송 시) 또는 null (빈 메시지)
+   */
+  emitChatMessage: (message: string) => string | null;
 }
 
 // ===== Context 생성 =====
@@ -284,6 +289,23 @@ export function TeamSocketProvider({ children, teamId }: TeamSocketProviderProps
     setTimeout(initializeSocket, 100);
   }, [disconnectSocket, initializeSocket]);
 
+  /**
+   * 채팅 메시지 전송
+   *
+   * - clientMsgId는 클라이언트가 생성 (낙관적 업데이트 / 추후 저장 dedup 키)
+   * - teamId는 보내지 않음 — 서버가 소켓에 캐싱된 teamId로 room을 식별
+   */
+  const emitChatMessage = useCallback((message: string): string | null => {
+    const text = message.trim();
+    if (!text) return null;
+    const clientMsgId = crypto.randomUUID();
+    socketRef.current?.emit(TeamSocketEvents.CHAT_MESSAGE, {
+      message: text,
+      clientMsgId,
+    });
+    return clientMsgId;
+  }, []);
+
   // 마운트 시 연결, 언마운트 시 해제
   useEffect(() => {
     initializeSocket();
@@ -303,8 +325,9 @@ export function TeamSocketProvider({ children, teamId }: TeamSocketProviderProps
       onlineUsers,
       setOnlineUsers,
       reconnect,
+      emitChatMessage,
     }),
-    [socket, isConnected, error, teamId, onlineUsers, reconnect]
+    [socket, isConnected, error, teamId, onlineUsers, reconnect, emitChatMessage]
   );
 
   return (

--- a/src/types/socket.ts
+++ b/src/types/socket.ts
@@ -6,6 +6,7 @@ export const TeamSocketEvents = {
   // Client → Server
   JOIN_TEAM: 'joinTeam',
   LEAVE_TEAM: 'leaveTeam',
+  CHAT_MESSAGE: 'chatMessage',
 
   // Server → Client (태스크)
   TASK_CREATED: 'taskCreated',
@@ -27,6 +28,9 @@ export const TeamSocketEvents = {
   // Server → Client (멤버 역할/상태)
   MEMBER_ROLE_CHANGED: 'memberRoleChanged',
   MEMBER_STATUS_CHANGED: 'memberStatusChanged',
+
+  // Server → Client (채팅)
+  CHAT_RECEIVED: 'chatReceived',
 
   // 공통
   JOINED_TEAM: 'joinedTeam',
@@ -193,6 +197,34 @@ export interface MemberStatusChangedPayload {
   changedBy: number;
 }
 
+// ===== 채팅 관련 타입 =====
+
+/**
+ * 채팅 메시지 전송 페이로드 (Client → Server)
+ *
+ * teamId는 보내지 않음 — 서버가 소켓에 캐싱된 teamId로 room을 식별한다.
+ * clientMsgId는 클라이언트가 생성한 메시지 식별자 (낙관적 업데이트 / 추후 저장 dedup 키).
+ */
+export interface ChatMessagePayload {
+  message: string;
+  clientMsgId: string;
+}
+
+/**
+ * 채팅 메시지 수신 페이로드 (Server → Client)
+ *
+ * messageId는 현재 clientMsgId를 에코한다. 추후 저장 도입 시 서버 발급 ID로 교체될 수 있음.
+ * timestamp는 서버가 생성한 ISO 문자열(UTC).
+ */
+export interface ChatReceivedPayload {
+  messageId: string;
+  teamId: number;
+  userId: number;
+  userName: string;
+  message: string;
+  timestamp: string;
+}
+
 // ===== Socket 타입 정의 =====
 
 /** Server → Client 이벤트 타입 맵 */
@@ -210,6 +242,7 @@ export interface ServerToClientEvents {
   [TeamSocketEvents.ONLINE_USERS]: (payload: OnlineUsersPayload) => void;
   [TeamSocketEvents.MEMBER_ROLE_CHANGED]: (payload: MemberRoleChangedPayload) => void;
   [TeamSocketEvents.MEMBER_STATUS_CHANGED]: (payload: MemberStatusChangedPayload) => void;
+  [TeamSocketEvents.CHAT_RECEIVED]: (payload: ChatReceivedPayload) => void;
   [TeamSocketEvents.JOINED_TEAM]: (payload: JoinedTeamPayload) => void;
   [TeamSocketEvents.LEFT_TEAM]: (payload: LeftTeamPayload) => void;
   [TeamSocketEvents.ERROR]: (payload: SocketErrorPayload) => void;
@@ -225,6 +258,7 @@ export interface ClientToServerEvents {
     data: { teamId: number },
     callback?: (response: LeftTeamPayload) => void,
   ) => void;
+  [TeamSocketEvents.CHAT_MESSAGE]: (data: ChatMessagePayload) => void;
 }
 
 /** 타입 안전한 Socket 인스턴스 */


### PR DESCRIPTION
- TeamChatPanel 신규: 바텀시트(OnlineUsersModal 패턴), clientMsgId 기반 dedup
- TeamSocketContext에 emitChatMessage(clientMsgId 생성·반환) 추가
- socket.ts에 chatMessage/chatReceived 이벤트·페이로드 타입 추가
- TeamBoard 헤더에 채팅 버튼 + 바텀시트 마운트
- 저장 없이 실시간 송수신, self는 dedup으로 중복 방지. tsc/lint 통과